### PR TITLE
Fix issues with hybrid workload and result collection

### DIFF
--- a/src/pt/haslab/htapbench/core/ClientBalancer.java
+++ b/src/pt/haslab/htapbench/core/ClientBalancer.java
@@ -220,7 +220,7 @@ public class ClientBalancer implements Runnable{
                 LOG.info("output: "+ output);
                 LOG.info("error: "+this.error);
                 
-                if(!saturated  && output < this.error_margin*this.projected_TPM){   
+                if(this.olapStreams == 0 || (!saturated  && output < this.error_margin*this.projected_TPM)){   
                     this.olapStreams++;
                    
                     this.workersOLAP.addAll(benchmarkModule.makeOLAPWorker(verbose,clock));

--- a/src/pt/haslab/htapbench/core/HTAPBench.java
+++ b/src/pt/haslab/htapbench/core/HTAPBench.java
@@ -873,34 +873,21 @@ public class HTAPBench {
         //      COLLECT RESULTS
         //***************************
         //Thread.sleep(1000*60*2);
-        Results tpcc = null;
-        Results tpch = null;
-        
-        try{
-            tpcc = oltp_runnable.getResults();
-            tpch = olap_runnable.getResults();
-        }
-        catch(NullPointerException e){
-
-        }
+        Results tpcc = oltp_runnable.getResults();
+        Results tpch = olap_runnable.getResults();
         
         boolean proceed = false;
         while(!proceed){
             
-            if(tpcc != null || tpch != null){
+            if(tpcc != null && tpch != null){
                 proceed = true;
-                break;
             }
             else{
-                try{
-                    tpcc = oltp_runnable.getResults();
-                    tpch = olap_runnable.getResults();
-                }
-                catch(NullPointerException e){
-                    
-                }
                 LOG.info("[HTAPB Thread]: Still waiting for results from OLTP and OLAP workers. Going to sleep for 1 minute..." );
                 Thread.sleep(60000);
+
+                tpcc = oltp_runnable.getResults();
+                tpch = olap_runnable.getResults();
             }
         }
         
@@ -947,31 +934,19 @@ public class HTAPBench {
         //      COLLECT RESULTS
         //***************************
         //Thread.sleep(1000*60*2);
-        Results tpcc = null;
-        
-        try{
-            tpcc = oltp_runnable.getResults();
-        }
-        catch(NullPointerException e){
-
-        }
+        Results tpcc = oltp_runnable.getResults();
         
         boolean proceed = false;
         while(!proceed){
             
             if(tpcc != null){
                 proceed = true;
-                break;
             }
             else{
-                try{
-                    tpcc = oltp_runnable.getResults();
-                }
-                catch(NullPointerException e){
-                    
-                }
                 LOG.info("[HTAPB Thread]: Still waiting for results from OLTP workers. Going to sleep for 1 minute..." );
                 Thread.sleep(60000);
+
+                tpcc = oltp_runnable.getResults();
             }
         }    
         //Thread.sleep(1000*60*2);
@@ -1013,31 +988,19 @@ public class HTAPBench {
         //      COLLECT RESULTS
         //***************************
         //Thread.sleep(1000*60*2);
-        Results tpch = null;
-        
-        try{
-            tpch = olap_runnable.getResults();
-        }
-        catch(NullPointerException e){
-
-        }
+        Results tpch = olap_runnable.getResults();
         
         boolean proceed = false;
         while(!proceed){
             
             if(tpch != null){
                 proceed = true;
-                break;
             }
             else{
-                try{
-                    tpch = olap_runnable.getResults();
-                }
-                catch(NullPointerException e){
-                    
-                }
-                LOG.info("[HTAPB Thread]: Still waiting for results from OLTP and OLAP workers. Going to sleep for 1 minute..." );
+                LOG.info("[HTAPB Thread]: Still waiting for results from OLAP workers. Going to sleep for 1 minute..." );
                 Thread.sleep(60000);
+
+                tpch = olap_runnable.getResults();
             }
         }
         //Thread.sleep(1000*60*2);


### PR DESCRIPTION
I encountered 2 issues with this benchmark, when running the hybrid workload:

1) Sometimes a NullPointerException occurs on line 683 of main() (HTAPBench.java), because runHybridWorkload() erroneously returns when EITHER tpcc or tpch results are non-null, instead of when BOTH tpcc and tpch are non-null.

2) Sometimes the ClientBalancer considers the system to be saturated before any OLAP streams have been launched, so then there will obviously be no OLAP results.


For (1), I changed the code so that when collecting results, only return when both tpcc AND tpch results are non-null.
I also took the liberty of doing a bit of code cleanup in all runXXXXWOrkLoad() methods:
- There were a few instances where try/catch of NullPointerException was being done, which served no purpose, as NullPointerException wasn't possible in the try-block (since it was just invoking a simple getter of an object reference).
- I changed the tpcc/tpch result fetch to AFTER the 60-second sleep, otherwise it could wait for up to 60 seconds longer than necessary to return the tpcc/tpch results.
- The "proceeed" while loop condition variable wasn't actually being used, so I removed the unnecessary "break", to maintain the intention of that condition variable.
- I fixed the log message in the runOLAPWorkload() method so that it didn't also erroneously refer to OLTP workers.

For (2), I made a simple code change so that at least one OLAP stream would be launched before considering whether the system was saturated. Without this code change, if no OLAP streams are launched, the code won't be able to return non-null tpch results.

